### PR TITLE
Make `base` lazy in collection types

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -53,9 +53,9 @@
       "problemMatcher": []
     },
     {
-      "label": "build",
+      "label": "ember s",
       "type": "shell",
-      "command": "ember s",
+      "command": "yarn ember s",
       "group": "build",
       "isBackground": true,
       "problemMatcher": []

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,7 +6,9 @@
     "target":
       "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
     // "module": "es2015",                    /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation */
+    "lib": [
+      "es2015"
+    ] /* Specify library files to be included in the compilation */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/packages/dsl/tsconfig.json
+++ b/packages/dsl/tsconfig.json
@@ -6,7 +6,9 @@
     "target":
       "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
     // "module": "es2015",                    /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation */
+    "lib": [
+      "es2015"
+    ] /* Specify library files to be included in the compilation */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,4 +1,4 @@
-export { BaseRecord, Record } from "./record";
+export { Record } from "./record";
 export {
   Opaque,
   Scalar,

--- a/packages/schema/src/types/describe/formatter.ts
+++ b/packages/schema/src/types/describe/formatter.ts
@@ -1,16 +1,16 @@
-import { BaseRecord } from "../../record";
+import { Record } from "../../record";
 import { Accumulator, Reporter, ReporterDelegate } from "./reporter";
 import { StringVisitor } from "./visitor";
 
 export type Formatter<Options = void, Result = string> = Options extends void
-  ? (record: BaseRecord) => Result
-  : (record: BaseRecord, options: Options) => Result;
+  ? (record: Record) => Result
+  : (record: Record, options: Options) => Result;
 
 export default function formatter<Buffer extends Accumulator<string>, Options>(
   delegate: ReporterDelegate<Buffer, string, Options>,
   BufferClass: { new (): Buffer }
 ): Formatter<Options, string> {
-  return ((type: BaseRecord, options?: Options): string => {
+  return ((type: Record, options?: Options): string => {
     let reporter = new Reporter<Buffer, string, typeof options>(
       delegate,
       options,

--- a/packages/schema/src/types/describe/formatters/graphql.ts
+++ b/packages/schema/src/types/describe/formatters/graphql.ts
@@ -1,5 +1,5 @@
 import { Dict, Option } from "ts-std";
-import { BaseRecord } from "../../../record";
+import { Record } from "../../../record";
 import { LabelledType } from "../../fundamental/value";
 import { titleize } from "../../utils";
 import formatter from "../formatter";
@@ -177,7 +177,7 @@ export interface GraphqlOptions {
 }
 
 export const graphql: ((
-  record: BaseRecord,
+  record: Record,
   options: GraphqlOptions
 ) => string) = formatter(delegate, BufferStack);
 

--- a/packages/schema/src/types/describe/formatters/json.ts
+++ b/packages/schema/src/types/describe/formatters/json.ts
@@ -1,5 +1,5 @@
 import { Dict, JSON, Option, unknown } from "ts-std";
-import { BaseRecord } from "../../../record";
+import { Record } from "../../../record";
 import {
   DictionaryLabel,
   GenericLabel,
@@ -141,6 +141,6 @@ function referenceOptions(
   return options;
 }
 
-export function toJSON(record: BaseRecord): unknown {
+export function toJSON(record: Record): unknown {
   return new JSONFormatter().record(record.label.type);
 }

--- a/packages/schema/src/types/describe/formatters/list-types.ts
+++ b/packages/schema/src/types/describe/formatters/list-types.ts
@@ -1,5 +1,5 @@
 import { Dict, unknown } from "ts-std";
-import { BaseRecord } from "../../../record";
+import { Record } from "../../../record";
 import {
   DictionaryLabel,
   GenericLabel,
@@ -46,6 +46,6 @@ class ListTypes implements RecursiveDelegate {
   }
 }
 
-export function listTypes(record: BaseRecord): unknown {
+export function listTypes(record: Record): unknown {
   return new ListTypes().record(record.label.type);
 }

--- a/packages/schema/src/types/describe/reporter.ts
+++ b/packages/schema/src/types/describe/reporter.ts
@@ -283,26 +283,32 @@ export abstract class ReporterState<Buffer, Inner, Options> {
 
   debug(operation: string): void {
     // tslint:disable:no-console
+
+    // @ts-ignore
     console.group(`${operation}`);
 
-    // return;
     // @ts-ignore
     console.log(`<- nesting: ${this.state.nesting}`);
 
     let buffer = this.state.buffer as { done?(): string };
 
     if (typeof buffer.done === "function") {
+      // @ts-ignore
       console.log(buffer.done().replace(/\n/g, "\\n\n"));
     } else {
+      // @ts-ignore
       console.log(JSON.stringify(this.state.buffer).replace(/\n/g, "\\n\n"));
     }
 
+    // @ts-ignore
     console.groupEnd();
+
     // tslint:enable:no-console
   }
 
   debugEnd() {
     // tslint:disable:no-console
+    // @ts-ignore
     console.groupEnd();
     // tslint:enable:no-console
   }

--- a/packages/schema/src/types/fundamental/iterator.ts
+++ b/packages/schema/src/types/fundamental/iterator.ts
@@ -1,17 +1,20 @@
 import { JSON, Option } from "ts-std";
 import { IteratorLabel, Label, typeNameOf } from "../label";
 import { ReferenceImpl } from "./reference";
-import { Type, baseType } from "./value";
+import { Type } from "./value";
 
 export class IteratorImpl extends ReferenceImpl {
   constructor(
     private inner: Type,
     private name: string | undefined,
     private args: JSON | undefined,
-    isRequired: boolean,
-    base: Option<Type>
+    isRequired: boolean
   ) {
-    super(isRequired, base);
+    super(isRequired);
+  }
+
+  get base(): Type {
+    return new IteratorImpl(this.inner.base, this.name, this.args, false);
   }
 
   get label(): Label<IteratorLabel> {
@@ -29,13 +32,7 @@ export class IteratorImpl extends ReferenceImpl {
   }
 
   required(isRequired = true): Type {
-    return new IteratorImpl(
-      this.inner,
-      this.name,
-      this.args,
-      isRequired,
-      this.base
-    );
+    return new IteratorImpl(this.inner, this.name, this.args, isRequired);
   }
 
   named(arg: Option<string>): Type {
@@ -43,19 +40,11 @@ export class IteratorImpl extends ReferenceImpl {
       this.inner,
       arg === null ? undefined : arg,
       this.args,
-      this.isRequired,
-      this.base
+      this.isRequired
     );
   }
 }
 
 export function hasMany(item: Type, options?: JSON): Type {
-  let draftType = new IteratorImpl(
-    baseType(item),
-    undefined,
-    options,
-    false,
-    null
-  );
-  return new IteratorImpl(item, undefined, options, false, draftType);
+  return new IteratorImpl(item, undefined, options, false);
 }

--- a/packages/schema/src/types/fundamental/list.ts
+++ b/packages/schema/src/types/fundamental/list.ts
@@ -2,7 +2,7 @@ import { ValidationBuilder, validators } from "@cross-check/dsl";
 import { Option, unknown } from "ts-std";
 import { Label, typeNameOf } from "../label";
 import { maybe } from "../utils";
-import { Type, baseType, parse, serialize } from "./value";
+import { Type, parse, serialize } from "./value";
 
 const isPresentArray = validators.is(
   (value: unknown[]): value is unknown[] => value.length > 0,
@@ -13,9 +13,12 @@ class ArrayImpl implements Type {
   constructor(
     private itemType: Type,
     private name: string | undefined,
-    readonly isRequired: boolean,
-    readonly base: Option<Type>
+    readonly isRequired: boolean
   ) {}
+
+  get base(): Type {
+    return new ArrayImpl(this.itemType.base, undefined, false);
+  }
 
   get label(): Label {
     let inner = this.itemType.required();
@@ -31,15 +34,14 @@ class ArrayImpl implements Type {
   }
 
   required(isRequired = true): Type {
-    return new ArrayImpl(this.itemType, this.name, isRequired, this.base);
+    return new ArrayImpl(this.itemType, this.name, isRequired);
   }
 
   named(arg: Option<string>): Type {
     return new ArrayImpl(
       this.itemType,
       arg === null ? undefined : arg,
-      this.isRequired,
-      this.base
+      this.isRequired
     );
   }
 
@@ -73,6 +75,5 @@ class ArrayImpl implements Type {
 }
 
 export function List(item: Type): Type {
-  let draftType = new ArrayImpl(baseType(item), undefined, false, null);
-  return new ArrayImpl(item, undefined, false, draftType);
+  return new ArrayImpl(item, undefined, false);
 }

--- a/packages/schema/src/types/fundamental/pointer.ts
+++ b/packages/schema/src/types/fundamental/pointer.ts
@@ -3,16 +3,19 @@ import { Option, unknown } from "ts-std";
 import { Label, PointerLabel, typeNameOf } from "../label";
 import { ANY } from "../std/scalars";
 import { ReferenceImpl } from "./reference";
-import { Type, baseType } from "./value";
+import { Type } from "./value";
 
 export class PointerImpl extends ReferenceImpl {
   constructor(
     private inner: Type,
     isRequired: boolean,
-    readonly base: Option<Type>,
     private name: string | undefined
   ) {
-    super(isRequired, base);
+    super(isRequired);
+  }
+
+  get base(): Type {
+    return new PointerImpl(this.inner.base.required(), false, undefined);
   }
 
   get label(): Label<PointerLabel> {
@@ -27,14 +30,13 @@ export class PointerImpl extends ReferenceImpl {
   }
 
   required(isRequired = true): Type {
-    return new PointerImpl(this.inner, isRequired, this.base, this.name);
+    return new PointerImpl(this.inner, isRequired, this.name);
   }
 
   named(arg: Option<string>): Type {
     return new PointerImpl(
       this.inner,
       this.isRequired,
-      this.base,
       arg === null ? undefined : arg
     );
   }
@@ -53,11 +55,5 @@ export class PointerImpl extends ReferenceImpl {
 }
 
 export function hasOne(entity: Type): Type {
-  let base = new PointerImpl(
-    baseType(entity).required(),
-    false,
-    null,
-    undefined
-  );
-  return new PointerImpl(entity.required(), false, base, undefined);
+  return new PointerImpl(entity.required(), false, undefined);
 }

--- a/packages/schema/src/types/fundamental/reference.ts
+++ b/packages/schema/src/types/fundamental/reference.ts
@@ -5,12 +5,13 @@ import { ANY } from "../std/scalars";
 import { Type } from "./value";
 
 export abstract class ReferenceImpl implements Type {
-  abstract label: Label<ReferenceLabel>;
+  abstract readonly label: Label<ReferenceLabel>;
+  abstract readonly base: Type;
 
-  constructor(readonly isRequired: boolean, readonly base: Option<Type>) {}
+  constructor(readonly isRequired: boolean) {}
 
-  abstract required(isRequired?: boolean): Type;
   abstract named(arg: Option<string>): Type;
+  abstract required(isRequired?: boolean): Type;
 
   validation(): ValidationBuilder<unknown> {
     return ANY;

--- a/packages/schema/src/types/fundamental/value.ts
+++ b/packages/schema/src/types/fundamental/value.ts
@@ -8,7 +8,7 @@ export type Pass = typeof Pass;
 
 export interface Type {
   readonly label: Label;
-  readonly base: Option<Type>;
+  readonly base: Type;
   readonly isRequired: boolean;
 
   required(isRequired?: boolean): Type;
@@ -25,14 +25,6 @@ export interface LabelledType<L extends TypeLabel = TypeLabel> extends Type {
 export interface NamedType<L extends TypeLabel = TypeLabel>
   extends LabelledType<L> {
   label: NamedLabel<L>;
-}
-
-export function baseType(type: Type): Type {
-  if (type.base === null) {
-    return type;
-  } else {
-    return type.base;
-  }
 }
 
 export function validationFor(

--- a/packages/schema/src/types/std/scalars.ts
+++ b/packages/schema/src/types/std/scalars.ts
@@ -10,7 +10,7 @@ import { Type, parse, serialize, validationFor } from "../fundamental/value";
 import { basic } from "../type";
 
 export abstract class Scalar implements Type {
-  readonly base = null;
+  readonly base = this;
   constructor(
     readonly isRequired: boolean = false,
     protected typeName?: string

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -6,7 +6,9 @@
     "target":
       "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
     // "module": "es2015",                    /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation */
+    "lib": [
+      "es2015"
+    ] /* Specify library files to be included in the compilation */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     "target":
       "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
     // "module": "es2015",                    /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation */
+    "lib": [
+      "es2015"
+    ] /* Specify library files to be included in the compilation */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Instead of eagerly creating the base type, lazily construct it. We plan to follow a similar strategy for other "views" into the types.