### PR TITLE
Restores List(Record)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,12 +8,11 @@
       "type": "shell",
       "command": "yarn problems",
       "problemMatcher": {
-        "base": "$tsc",
-        "owner": "ts"
+        "base": "$tsc"
       },
       "presentation": {
         "echo": false,
-        "reveal": "always",
+        "reveal": "silent",
         "focus": false,
         "panel": "shared"
       },

--- a/packages/dsl/src/validators/array.ts
+++ b/packages/dsl/src/validators/array.ts
@@ -14,7 +14,7 @@ function mapError(
   { path, message }: ValidationError,
   index: number
 ): ValidationError {
-  return { path: [...path, String(index)], message };
+  return { path: [String(index), ...path], message };
 }
 
 /**

--- a/packages/schema/src/types/describe/formatters/json.ts
+++ b/packages/schema/src/types/describe/formatters/json.ts
@@ -179,6 +179,9 @@ export function toJSON(
   record: RecordBuilder | RecordImpl,
   registry: Registry = REGISTRY
 ): JSONRecord {
-  let desc = visitorDescriptor(record.dehydrate(), registry);
+  let desc: visitor.Dictionary | visitor.Record = visitorDescriptor(
+    record.dehydrate(),
+    registry
+  );
   return new JSONFormatter().record(desc);
 }

--- a/packages/schema/src/types/fundamental/dictionary.ts
+++ b/packages/schema/src/types/fundamental/dictionary.ts
@@ -76,7 +76,7 @@ export interface DictionaryOptions {
 }
 
 export function Dictionary(
-  members: Dict<builders.TypeBuilder>
+  members: Dict<builders.TypeBuilderMember>
 ): builders.DictionaryBuilder {
   return new builders.DictionaryBuilder({ members });
 }

--- a/packages/schema/src/types/fundamental/list.ts
+++ b/packages/schema/src/types/fundamental/list.ts
@@ -47,11 +47,11 @@ export class ListImpl implements Type {
 }
 
 export function List(
-  contents: builders.TypeBuilder,
+  contents: builders.TypeBuilderMember,
   options?: { allowEmpty: boolean }
 ): builders.ListBuilder {
   return new builders.ListBuilder({
     args: options,
-    contents: contents.required()
+    contents: contents.builder.required()
   });
 }

--- a/packages/schema/test/list-of-record-test.ts
+++ b/packages/schema/test/list-of-record-test.ts
@@ -1,0 +1,122 @@
+import { REGISTRY, Record, types } from "@cross-check/schema";
+import { keysError, missingError, typeError, validate } from "./support";
+
+QUnit.module(
+  "[schema] issue #9 - List(Record) is equivalent to List(Named(Dictionary))",
+  () => {
+    QUnit.module("optional list", () => {
+      QUnit.test("validation", async assert => {
+        const registry = REGISTRY.clone();
+
+        const Inner = Record("inner", {
+          fields: {
+            hed: types.SingleWord().required()
+          },
+          registry
+        });
+
+        const TestCase = Record("list-of-record", {
+          fields: {
+            list: types.List(Inner)
+          },
+          registry
+        });
+
+        assert.deepEqual(await validate(TestCase.with(), { list: null }), []);
+        assert.deepEqual(
+          await validate(TestCase.with(), { list: [null] }),
+          [missingError("list.0")],
+          "a list's contents must not be null"
+        );
+        assert.deepEqual(
+          await validate(TestCase.with({ draft: true }), { list: [null] }),
+          [missingError("list.0")],
+          "a list's contents may not be null even in draft mode"
+        );
+        assert.deepEqual(
+          await validate(TestCase.with(), { list: [{}] }),
+          [keysError({ missing: ["hed"], path: "list.0" })],
+          "a list's Record contents must pass the inner shape validations"
+        );
+        assert.deepEqual(
+          await validate(TestCase.with({ draft: true }), { list: [{}] }),
+          [keysError({ missing: ["hed"], path: "list.0" })],
+          "a list's Record contents must pass the inner shape validations even in draft mode"
+        );
+        assert.deepEqual(
+          await validate(TestCase.with({ strictKeys: false }), { list: [{}] }),
+          [],
+          "a list's Record contents need not pass the inner shape validations when strict keys are disabled"
+        );
+        assert.deepEqual(
+          await validate(TestCase.with(), { list: [{ hed: 1 }] }),
+          [typeError("string", "list.0.hed")],
+          "a list's Record contents must pass the inner type validations"
+        );
+        assert.deepEqual(
+          await validate(TestCase.with({ draft: true }), {
+            list: [{ hed: 1 }]
+          }),
+          [typeError("string", "list.0.hed")],
+          "a list's Record contents must pass the inner type validations even in draft mode"
+        );
+        assert.deepEqual(
+          await validate(TestCase.with(), { list: [{ hed: "hello world" }] }),
+          [typeError("string:single-word", "list.0.hed")],
+          "a list's Record contents must pass the scalar validations"
+        );
+        assert.deepEqual(
+          await validate(TestCase.with({ draft: true }), {
+            list: [{ hed: "hello world" }]
+          }),
+          [],
+          "a list's Record contents need not pass the scalar validations in draft mode"
+        );
+      });
+    });
+
+    QUnit.module("required list", () => {
+      QUnit.test("validation", async assert => {
+        const registry = REGISTRY.clone();
+
+        const Inner = Record("inner", {
+          fields: {
+            hed: types.Text().required()
+          },
+          registry
+        });
+
+        const TestCase = Record("list-of-record", {
+          fields: {
+            list: types.List(Inner).required()
+          },
+          registry
+        });
+
+        assert.deepEqual(
+          await validate(TestCase.with(), { list: null }),
+          [missingError("list")],
+          "A required list must be present"
+        );
+
+        assert.deepEqual(
+          await validate(TestCase.with({ draft: true }), { list: null }),
+          [],
+          "A required list may be null in draft mode"
+        );
+
+        assert.deepEqual(
+          await validate(TestCase.with({ draft: true }), {}),
+          [keysError({ missing: ["list"] })],
+          "Strict keys are still required in draft mode"
+        );
+
+        assert.deepEqual(
+          await validate(TestCase.with({ strictKeys: false }), {}),
+          [missingError("list")],
+          "Required fields are still required even if strictKeys are false"
+        );
+      });
+    });
+  }
+);

--- a/packages/schema/test/readonly-test.ts
+++ b/packages/schema/test/readonly-test.ts
@@ -1,5 +1,4 @@
-import { REGISTRY, Record } from "@cross-check/schema";
-import { TypeBuilder } from "@cross-check/schema/src/descriptors/builders";
+import { REGISTRY, Record, builders } from "@cross-check/schema";
 import { ENV, keysError } from "./support";
 import { ISODate } from "./support/date";
 
@@ -38,7 +37,7 @@ QUnit.test("no readonly() means always required", async assert => {
 
 async function testMode(
   assert: typeof QUnit.assert,
-  type: TypeBuilder,
+  type: builders.TypeBuilder,
   options: { read?: true; create?: true; update?: true }
 ) {
   let modes: Array<"create" | "read" | "update"> = ["create", "read", "update"];


### PR DESCRIPTION
Fixes #9

Previously, Records were a special alternative type, and in particular
RecordBuilder didn't implement TypeBuilder.

This commit creates a new, more abstract interface called
TypeBuilderMember, which simply requires that an object that wants to be
allowed to go inside of List() or Dictionary() must provide a builder
property that returns a real builder.

In practice, this means that when you put a Record into a List or
Dictionary, it effectively turns into its equivalent Dictionary for
validation purposes. It is still serialized as an alias, though.