### PR TITLE
Better test infrastructure

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -14,3 +14,8 @@ export { types };
 export * from "./descriptors";
 export { DEBUG_LOG } from "./debug";
 export { Registry, REGISTRY } from "./registry";
+export {
+  Std,
+  Formatters as StdFormatters,
+  RecordFormatters as StdRecordFormatters
+} from "./std";

--- a/packages/schema/src/registry.ts
+++ b/packages/schema/src/registry.ts
@@ -1,6 +1,6 @@
-import { RecordBuilder } from "@cross-check/schema/src/record";
 import { Dict, JSONObject, Option, assert, dict, expect } from "ts-std";
 import { dehydrated } from "./descriptors";
+import { RecordBuilder, RecordImpl } from "./record";
 import * as type from "./type";
 import { DictionaryImpl } from "./types/fundamental";
 import { JSONValue, mapDict } from "./utils";
@@ -156,6 +156,14 @@ export class Registry {
     );
 
     this.types.Record.set(name, new Record(name, dictionary, metadata));
+  }
+
+  getRecordImpl(
+    name: string,
+    params: dehydrated.HydrateParameters
+  ): RecordImpl {
+    let { dictionary, metadata } = this.getRecord(name, params);
+    return new RecordImpl(dictionary, metadata, name);
   }
 
   getRecord(

--- a/packages/schema/src/std.ts
+++ b/packages/schema/src/std.ts
@@ -1,0 +1,138 @@
+import { Environment, ValidationError, validate } from "@cross-check/core";
+import build from "@cross-check/dsl";
+import Task from "no-show";
+import { Dict } from "ts-std";
+import { dehydrated } from "./descriptors";
+import { RecordImpl } from "./record";
+import { Registry } from "./registry";
+import {
+  GraphqlOptions,
+  JSONRecord,
+  TypescriptOptions,
+  describe,
+  graphql,
+  listTypes,
+  schemaFormat,
+  toJSON,
+  typescript
+} from "./types";
+
+export class Std {
+  constructor(
+    readonly registry: Registry,
+    readonly params: dehydrated.HydrateParameters,
+    readonly env: Environment
+  ) {}
+
+  validate(name: string, obj: Dict): Task<ValidationError[]> {
+    let { dictionary } = this.registry.getRecord(name, this.params);
+
+    return validate(obj, build(dictionary.validation()), null, this.env);
+  }
+
+  hydrate(name: string): RecordImpl {
+    return this.registry.getRecordImpl(name, this.params);
+  }
+
+  listTypes(name: string): string[] {
+    return listTypes(this.hydrate(name), this.registry);
+  }
+
+  get formatters(): Formatters {
+    return new Formatters(this.registry, this.params);
+  }
+
+  get validation(): (name: string, value: Dict) => Task<ValidationError[]> {
+    return (name: string, value: Dict) => {
+      let impl = this.hydrate(name);
+      return impl.validate(value, this.env);
+    };
+  }
+
+  validator(name: string): (value: Dict) => Task<ValidationError[]> {
+    return (value: Dict) => {
+      let impl = this.hydrate(name);
+      return impl.validate(value, this.env);
+    };
+  }
+
+  format(name: string): RecordFormatters {
+    return new RecordFormatters(this.registry, this.params, name);
+  }
+}
+
+export class Formatters {
+  constructor(
+    private registry: Registry,
+    private params: dehydrated.HydrateParameters
+  ) {}
+
+  describe(name: string): string {
+    return describe(
+      this.registry,
+      this.registry.getRecordImpl(name, this.params)
+    );
+  }
+
+  schemaFormat(name: string): string {
+    return schemaFormat(
+      this.registry,
+      this.registry.getRecordImpl(name, this.params)
+    );
+  }
+
+  typescript(name: string, options: TypescriptOptions): string {
+    return typescript(
+      this.registry,
+      this.registry.getRecordImpl(name, this.params),
+      options
+    );
+  }
+
+  graphql(name: string, options: GraphqlOptions): string {
+    return graphql(
+      this.registry,
+      this.registry.getRecordImpl(name, this.params),
+      options
+    );
+  }
+
+  toJSON(name: string): JSONRecord {
+    return toJSON(
+      this.registry.getRecordImpl(name, this.params),
+      this.registry
+    );
+  }
+}
+
+export class RecordFormatters {
+  private inner: Formatters;
+
+  constructor(
+    registry: Registry,
+    params: dehydrated.HydrateParameters,
+    private name: string
+  ) {
+    this.inner = new Formatters(registry, params);
+  }
+
+  describe(): string {
+    return this.inner.describe(this.name);
+  }
+
+  schemaFormat(): string {
+    return this.inner.schemaFormat(this.name);
+  }
+
+  typescript(options: TypescriptOptions): string {
+    return this.inner.typescript(this.name, options);
+  }
+
+  graphql(options: GraphqlOptions): string {
+    return this.inner.graphql(this.name, options);
+  }
+
+  toJSON(name: string): JSONRecord {
+    return this.inner.toJSON(name);
+  }
+}

--- a/packages/schema/src/types/describe/formatters/json.ts
+++ b/packages/schema/src/types/describe/formatters/json.ts
@@ -129,12 +129,7 @@ class JSONFormatter implements visitor.RecursiveDelegate<JSONTypes> {
     };
   }
 
-  record(
-    descriptor: visitor.Record | visitor.Dictionary
-  ): {
-    fields: Dict<Item>;
-    metadata?: Option<JSONValue>;
-  } {
+  record(descriptor: visitor.Record | visitor.Dictionary): JSONRecord {
     return {
       fields: this.dictionaryOrRecord(descriptor),
       metadata: "metadata" in descriptor ? descriptor.metadata : undefined

--- a/packages/schema/src/types/describe/formatters/list-types.ts
+++ b/packages/schema/src/types/describe/formatters/list-types.ts
@@ -1,6 +1,4 @@
 import { Dict } from "ts-std";
-import { RecordBuilder } from "../../../record";
-import { Registry } from "../../../registry";
 import * as visitor from "../visitor";
 
 export interface ListTypesTypes extends visitor.RecursiveDelegateTypes {
@@ -51,6 +49,11 @@ class ListTypes implements visitor.RecursiveDelegate<ListTypesTypes> {
   }
 }
 
-export function listTypes(record: RecordBuilder, registry: Registry): unknown {
-  return new ListTypes().record(record.descriptor(registry));
-}
+export const listTypes = visitor.recursive<ListTypesTypes>(ListTypes);
+
+// export function listTypes(
+//   record: FormattableRecord,
+//   registry: Registry
+// ): unknown {
+//   return new ListTypes().record(record.descriptor(registry));
+// }

--- a/packages/schema/test/formatting/describe-test.ts
+++ b/packages/schema/test/formatting/describe-test.ts
@@ -1,16 +1,10 @@
 import { module, strip } from "../support";
-import {
-  MediumArticle,
-  Nesting,
-  Related,
-  SimpleArticle
-} from "../support/records";
 
 const mod = module("[schema] formatting - describe");
 
-mod.test("simple", (assert, { describe }) => {
+mod.test("simple", (assert, { format }) => {
   assert.equal(
-    describe(SimpleArticle),
+    format.published.describe("SimpleArticle"),
 
     strip`
       {
@@ -34,9 +28,9 @@ mod.test("simple", (assert, { describe }) => {
   // );
 });
 
-mod.test("detailed", (assert, { describe }) => {
+mod.test("detailed", (assert, { format }) => {
   assert.equal(
-    describe(MediumArticle),
+    format.published.describe("MediumArticle"),
 
     strip`
       {
@@ -92,9 +86,9 @@ mod.test("detailed", (assert, { describe }) => {
   // );
 });
 
-mod.test("relationships", (assert, { describe }) => {
+mod.test("relationships", (assert, { format }) => {
   assert.equal(
-    describe(Related),
+    format.published.describe("Related"),
 
     strip`
       {
@@ -120,9 +114,9 @@ mod.test("relationships", (assert, { describe }) => {
   // );
 });
 
-mod.test("nested", (assert, { describe }) => {
+mod.test("nested", (assert, { format }) => {
   assert.equal(
-    describe(Nesting),
+    format.published.describe("Nesting"),
 
     strip`
       {

--- a/packages/schema/test/formatting/graphql-test.ts
+++ b/packages/schema/test/formatting/graphql-test.ts
@@ -1,11 +1,13 @@
 import { GRAPHQL_SCALAR_MAP, module, strip } from "../support";
-import { MediumArticle, Related, SimpleArticle } from "../support/records";
 
 let mod = module("[schema] formatting - graphql");
 
-mod.test("simple", (assert, { registry, graphql }) => {
+mod.test("simple", (assert, { format }) => {
   assert.equal(
-    graphql(SimpleArticle, { name: "Simple", scalarMap: GRAPHQL_SCALAR_MAP }),
+    format.published.graphql("SimpleArticle", {
+      name: "Simple",
+      scalarMap: GRAPHQL_SCALAR_MAP
+    }),
     strip`
       type Simple {
         hed: SingleLine!
@@ -16,7 +18,7 @@ mod.test("simple", (assert, { registry, graphql }) => {
   );
 
   assert.equal(
-    graphql(SimpleArticle.with({ draft: true, registry }), {
+    format.draft.graphql("SimpleArticle", {
       name: "Simple",
       scalarMap: GRAPHQL_SCALAR_MAP
     }),
@@ -30,9 +32,9 @@ mod.test("simple", (assert, { registry, graphql }) => {
   );
 });
 
-mod.test("detailed", (assert, { graphql }) => {
+mod.test("detailed", (assert, { format }) => {
   assert.equal(
-    graphql(MediumArticle, {
+    format.published.graphql("MediumArticle", {
       name: "MediumArticle",
       scalarMap: GRAPHQL_SCALAR_MAP
     }),
@@ -69,9 +71,12 @@ mod.test("detailed", (assert, { graphql }) => {
   );
 });
 
-mod.test("relationships", (assert, { graphql }) => {
+mod.test("relationships", (assert, { format }) => {
   assert.equal(
-    graphql(Related, { name: "Related", scalarMap: GRAPHQL_SCALAR_MAP }),
+    format.published.graphql("Related", {
+      name: "Related",
+      scalarMap: GRAPHQL_SCALAR_MAP
+    }),
 
     strip`
       type Related {

--- a/packages/schema/test/formatting/list-types-test.ts
+++ b/packages/schema/test/formatting/list-types-test.ts
@@ -1,15 +1,20 @@
-import { listTypes } from "@cross-check/schema";
 import { module } from "../support";
-import { MediumArticle, SimpleArticle } from "../support/records";
 
 const mod = module("[schema] formatting - listTypes");
 
-mod.test("simple", (assert, { registry }) => {
-  assert.deepEqual(listTypes(SimpleArticle, registry), ["SingleLine", "Text"]);
+mod.test("simple", (assert, { std }) => {
+  assert.deepEqual(std.published.listTypes("SimpleArticle"), [
+    "SingleLine",
+    "Text"
+  ]);
 });
 
-mod.test("detailed", (assert, { registry }) => {
-  assert.deepEqual(listTypes(MediumArticle, registry), [
+mod.test("simple - draft", (assert, { std }) => {
+  assert.deepEqual(std.draft.listTypes("SimpleArticle"), ["Text"]);
+});
+
+mod.test("detailed", (assert, { std }) => {
+  assert.deepEqual(std.published.listTypes("MediumArticle"), [
     "Dictionary",
     "ISODate",
     "Integer",
@@ -18,5 +23,15 @@ mod.test("detailed", (assert, { registry }) => {
     "SingleWord",
     "Text",
     "Url"
+  ]);
+});
+
+mod.test("detailed - draft", (assert, { std }) => {
+  assert.deepEqual(std.draft.listTypes("MediumArticle"), [
+    "Dictionary",
+    "ISODate",
+    "Integer",
+    "List",
+    "Text"
   ]);
 });

--- a/packages/schema/test/formatting/schema-format-test.ts
+++ b/packages/schema/test/formatting/schema-format-test.ts
@@ -1,11 +1,10 @@
 import { module, strip } from "../support";
-import { MediumArticle, Related, SimpleArticle } from "../support/records";
 
 const mod = module("[schema] formatting - schemaFormat");
 
-mod.test("simple", (assert, { schemaFormat }) => {
+mod.test("simple", (assert, { format }) => {
   assert.equal(
-    schemaFormat(SimpleArticle),
+    format.published.schemaFormat("SimpleArticle"),
 
     strip`
       Record("SimpleArticle", {
@@ -20,9 +19,9 @@ mod.test("simple", (assert, { schemaFormat }) => {
   );
 });
 
-mod.test("detailed - published", (assert, { schemaFormat }) => {
+mod.test("detailed - published", (assert, { format }) => {
   assert.equal(
-    schemaFormat(MediumArticle),
+    format.published.schemaFormat("MediumArticle"),
 
     strip`
       Record("MediumArticle", {
@@ -53,9 +52,9 @@ mod.test("detailed - published", (assert, { schemaFormat }) => {
   );
 });
 
-mod.test("relationships", (assert, { schemaFormat }) => {
+mod.test("relationships", (assert, { format }) => {
   assert.equal(
-    schemaFormat(Related),
+    format.published.schemaFormat("Related"),
 
     strip`
       Record("Related", {

--- a/packages/schema/test/formatting/to-json-test.ts
+++ b/packages/schema/test/formatting/to-json-test.ts
@@ -1,10 +1,9 @@
 import { module } from "../support";
-import { MediumArticle, Related, SimpleArticle } from "../support/records";
 
 const mod = module("[schema] formatting - toJSON");
 
-mod.test("simple - published", (assert, { toJSON }) => {
-  assert.deepEqual(toJSON(SimpleArticle), {
+mod.test("simple - published", (assert, { format }) => {
+  assert.deepEqual(format.published.toJSON("SimpleArticle"), {
     fields: {
       hed: { type: "SingleLine", required: true },
       dek: { type: "Text", required: false, args: { allowEmpty: true } },
@@ -18,8 +17,8 @@ mod.test("simple - published", (assert, { toJSON }) => {
   });
 });
 
-mod.test("simple - draft", (assert, { registry, toJSON }) => {
-  assert.deepEqual(toJSON(SimpleArticle.with({ draft: true, registry })), {
+mod.test("simple - draft", (assert, { format }) => {
+  assert.deepEqual(format.draft.toJSON("SimpleArticle"), {
     fields: {
       hed: { type: "Text", required: false, args: { allowEmpty: true } },
       dek: { type: "Text", required: false, args: { allowEmpty: true } },
@@ -32,8 +31,8 @@ mod.test("simple - draft", (assert, { registry, toJSON }) => {
   });
 });
 
-mod.test("detailed - published", (assert, { toJSON }) => {
-  let actual = toJSON(MediumArticle);
+mod.test("detailed - published", (assert, { format }) => {
+  let actual = format.published.toJSON("MediumArticle");
   let fields = {
     hed: { type: "SingleLine", required: true },
     dek: { type: "Text", required: false, args: { allowEmpty: true } },
@@ -116,8 +115,8 @@ mod.test("detailed - published", (assert, { toJSON }) => {
   assert.deepEqual(actual, expected);
 });
 
-mod.test("detailed - draft", (assert, { registry, toJSON }) => {
-  let actual = toJSON(MediumArticle.with({ draft: true, registry }));
+mod.test("detailed - draft", (assert, { format }) => {
+  let actual = format.draft.toJSON("MediumArticle");
   let fields = {
     hed: { type: "Text", required: true },
     dek: { type: "Text", required: false, args: { allowEmpty: true } },
@@ -185,9 +184,9 @@ mod.test("detailed - draft", (assert, { registry, toJSON }) => {
   assert.deepEqual(actual, expected);
 });
 
-mod.test("relationships - published", (assert, { toJSON }) => {
+mod.test("relationships - published", (assert, { format }) => {
   assert.deepEqual(
-    toJSON(Related),
+    format.published.toJSON("Related"),
     {
       fields: {
         first: {
@@ -224,9 +223,9 @@ mod.test("relationships - published", (assert, { toJSON }) => {
   );
 });
 
-mod.test("relationships - draft", (assert, { registry, toJSON }) => {
+mod.test("relationships - draft", (assert, { format }) => {
   assert.deepEqual(
-    toJSON(Related.with({ draft: true, registry })),
+    format.draft.toJSON("Related"),
 
     {
       fields: {

--- a/packages/schema/test/formatting/typescript-test.ts
+++ b/packages/schema/test/formatting/typescript-test.ts
@@ -1,11 +1,10 @@
 import { module, strip } from "../support";
-import { MediumArticle, SimpleArticle } from "../support/records";
 
 const mod = module("[schema] formatting - typescript");
 
-mod.test("simple - published", (assert, { typescript }) => {
+mod.test("simple - published", (assert, { format }) => {
   assert.equal(
-    typescript(SimpleArticle, { name: "SimpleArticle" }),
+    format.published.typescript("SimpleArticle", { name: "SimpleArticle" }),
 
     strip`
         export interface SimpleArticle {
@@ -17,9 +16,9 @@ mod.test("simple - published", (assert, { typescript }) => {
   );
 });
 
-mod.test("simple - draft", (assert, { registry, typescript }) => {
+mod.test("simple - draft", (assert, { format }) => {
   assert.equal(
-    typescript(SimpleArticle.with({ draft: true, registry }), {
+    format.draft.typescript("SimpleArticle", {
       name: "SimpleArticleDraft"
     }),
 
@@ -33,9 +32,9 @@ mod.test("simple - draft", (assert, { registry, typescript }) => {
   );
 });
 
-mod.test("detailed - published", (assert, { typescript }) => {
+mod.test("detailed - published", (assert, { format }) => {
   assert.equal(
-    typescript(MediumArticle, { name: "MediumArticle" }),
+    format.published.typescript("MediumArticle", { name: "MediumArticle" }),
 
     strip`
       export interface MediumArticle {
@@ -63,9 +62,9 @@ mod.test("detailed - published", (assert, { typescript }) => {
   );
 });
 
-mod.test("detailed - draft", (assert, { registry, typescript }) => {
+mod.test("detailed - draft", (assert, { format }) => {
   assert.equal(
-    typescript(MediumArticle.with({ draft: true, registry }), {
+    format.draft.typescript("MediumArticle", {
       name: "MediumArticleDraft"
     }),
 

--- a/packages/schema/test/support/module.ts
+++ b/packages/schema/test/support/module.ts
@@ -70,9 +70,6 @@ export interface SubjectTestStdValidate {
 
 export interface TestState {
   registry: Registry;
-  validateDraft: ValidateFunction;
-  validateSloppy: ValidateFunction;
-  validatePublished: ValidateFunction;
   validate: TestStdValidate;
   std: TestStd;
   format: TestStdFormatters;
@@ -80,9 +77,6 @@ export interface TestState {
 
 export interface SubjectTestState {
   registry: Registry;
-  validateDraft: SubjectValidateFunction;
-  validateSloppy: SubjectValidateFunction;
-  validatePublished: SubjectValidateFunction;
   validate: SubjectTestStdValidate;
   std: TestStd;
   format: SubjectTestStdFormatters;
@@ -208,17 +202,6 @@ export function module(
     QUnit.test(description, assert =>
       callback(assert, {
         registry,
-        validateDraft(builder, obj) {
-          return validateDraft(builder, obj, registry);
-        },
-
-        validatePublished(builder, obj) {
-          return validatePublished(builder, obj, registry);
-        },
-
-        validateSloppy(builder, obj) {
-          return validateSloppy(builder, obj, registry);
-        },
 
         validate: {
           draft: draft.validation,
@@ -257,17 +240,6 @@ export function module(
       QUnit.test(description, assert =>
         callback(assert, {
           registry,
-          validateDraft(obj) {
-            return validateDraft(subject, obj, registry);
-          },
-
-          validatePublished(obj) {
-            return validatePublished(subject, obj, registry);
-          },
-
-          validateSloppy(obj) {
-            return validateSloppy(subject, obj, registry);
-          },
 
           validate: {
             draft: draft.validator(subject.name),
@@ -301,45 +273,4 @@ export function module(
       nestedCallback(testFunction);
     });
   }
-}
-
-export type ValidateFunction = (
-  record: RecordBuilder,
-  obj: Dict
-) => Task<ValidationError[]>;
-
-export type SubjectValidateFunction = (obj: Dict) => Task<ValidationError[]>;
-
-function validate(
-  record: RecordBuilder,
-  obj: Dict<unknown>,
-  registry: Registry
-): Task<ValidationError[]> {
-  return record.with({ registry }).validate(obj, ENV);
-}
-
-function validateDraft(
-  record: RecordBuilder,
-  obj: Dict<unknown>,
-  registry: Registry
-): Task<ValidationError[]> {
-  return record.with({ registry, draft: true }).validate(obj, ENV);
-}
-
-function validateSloppy(
-  record: RecordBuilder,
-  obj: Dict<unknown>,
-  registry: Registry
-): Task<ValidationError[]> {
-  return record
-    .with({ registry, draft: true, strictKeys: false })
-    .validate(obj, ENV);
-}
-
-function validatePublished(
-  record: RecordBuilder,
-  obj: Dict<unknown>,
-  registry: Registry
-): Task<ValidationError[]> {
-  return validate(record, obj, registry);
 }


### PR DESCRIPTION
Now that the registry is required to be threaded around more, these commits improve the test harness so that the registry is automatically created and communicated to the tests. The tests also get helpers like the formatters and draft/published that are curried over the registry for convenience.