### PR TITLE
Rename Env -> ObjectModel and Std -> Env

### DIFF
--- a/packages/core/src/descriptor.ts
+++ b/packages/core/src/descriptor.ts
@@ -104,6 +104,9 @@ export interface ObjectModel {
   asList(object: unknown): Option<Iterable<unknown> | Array<unknown>>;
 }
 
+/** @deprecated */
+export type Environment = ObjectModel;
+
 /**
  * @api primitive
  *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export {
   ErrorMessage,
   ValidationError,
   ObjectModel,
+  Environment,
   ValidatorFactory,
   Validator,
   ValidationDescriptor


### PR DESCRIPTION
This is a big naming change, but it's long overdue, and frees up space
in schema to call the unifying abstraction an "environment" (which it
is).