### PR TITLE
Add failing tests via self-referential relationship to MediumArticle

### DIFF
--- a/packages/schema/test/detailed-test.ts
+++ b/packages/schema/test/detailed-test.ts
@@ -14,6 +14,7 @@ function create(object: Dict = {}) {
     categories: null,
     geo: null,
     contributors: null,
+    relatedArticles: null,
     ...object
   };
 }

--- a/packages/schema/test/support/records.ts
+++ b/packages/schema/test/support/records.ts
@@ -45,7 +45,8 @@ export const MediumArticle: Record = Record("MediumArticle", {
     }),
     contributors: types.List(
       types.Dictionary({ first: types.SingleLine(), last: types.SingleLine() })
-    )
+    ),
+    relatedArticles: types.hasMany("MediumArticle")
   },
   metadata: {
     collectionName: "medium-articles",


### PR DESCRIPTION
- This results in stack overflow errors, presumably the hydration
becomes recursive.

@wycats This probably isn't super helpful but here's what causes the issue I ran into most recently. We do no have many use-cases like this but there's at least one, so it would be great if it was supported.

Also, going forward a Category schema would probably need a `children` property that is a self-referential relationship, for example.

