### PR TITLE
Add support for self-referential types

### DIFF
--- a/packages/schema/src/descriptors/builders.ts
+++ b/packages/schema/src/descriptors/builders.ts
@@ -1,6 +1,6 @@
 import { Dict, JSONObject, Option } from "ts-std";
 import { RegistryName } from "../registry";
-import { DictionaryImpl, ListArgs } from "../types";
+import { DictionaryType, ListArgs } from "../types";
 import { JSONValue, mapDict } from "../utils";
 import * as dehydrated from "./dehydrated";
 
@@ -258,7 +258,7 @@ export class PrimitiveBuilder extends AbstractTypeBuilder<
 export interface RecordState {
   name: string;
   metadata: JSONObject | null;
-  inner: DictionaryImpl;
+  inner: DictionaryType;
 }
 
 ///// Helper Functions /////

--- a/packages/schema/src/descriptors/index.ts
+++ b/packages/schema/src/descriptors/index.ts
@@ -1,5 +1,6 @@
 import * as builders from "./builders";
 import * as dehydrated from "./dehydrated";
 
+export { HydrateParameters, Hydrator } from "./dehydrated";
 export * from "./descriptor-debug";
 export { builders, dehydrated };

--- a/packages/schema/src/record.ts
+++ b/packages/schema/src/record.ts
@@ -13,7 +13,6 @@ import { visitorDescriptor } from "./descriptors/dehydrated";
 import { Registry } from "./registry";
 import { Type } from "./type";
 import * as visitor from "./types/describe/visitor";
-import { DictionaryImpl } from "./types/fundamental";
 import { mapDict } from "./utils";
 
 export interface RecordState {
@@ -77,7 +76,7 @@ export class RecordBuilder
 
 export class RecordImpl implements Type, Buildable, FormattableRecord {
   constructor(
-    private dictionary: DictionaryImpl,
+    private dictionary: Type,
     readonly metadata: JSONObject | null,
     readonly name: string
   ) {}
@@ -87,7 +86,7 @@ export class RecordImpl implements Type, Buildable, FormattableRecord {
   }
 
   dehydrate(): dehydrated.Dictionary {
-    return this.dictionary.dehydrate();
+    return this.dictionary.dehydrate() as dehydrated.Dictionary;
   }
 
   validate(obj: Dict, objectModel: ObjectModel): Task<ValidationError[]> {

--- a/packages/schema/src/types/describe/formatters/list-types.ts
+++ b/packages/schema/src/types/describe/formatters/list-types.ts
@@ -26,8 +26,12 @@ class ListTypes implements visitor.RecursiveDelegate<ListTypesTypes> {
 
   generic(of: Dict, descriptor: visitor.Container): Dict {
     let kind = descriptor.type;
-    let name = `${kind[0].toUpperCase()}${kind.slice(1)}`;
-    return { ...of, [name]: true };
+
+    if (kind === "List") {
+      return { ...of, List: true };
+    } else {
+      return of;
+    }
   }
 
   dictionary(descriptor: visitor.Dictionary): Dict {

--- a/packages/schema/src/types/fundamental/dictionary.ts
+++ b/packages/schema/src/types/fundamental/dictionary.ts
@@ -8,7 +8,11 @@ export interface DictionaryImplOptions {
   strictKeys: boolean;
 }
 
-export class DictionaryImpl implements Type {
+export interface DictionaryType extends Type {
+  readonly members: Dict<Type>;
+}
+
+export class DictionaryImpl implements DictionaryType {
   constructor(
     readonly members: Dict<Type>,
     private options: DictionaryImplOptions

--- a/packages/schema/src/types/fundamental/iterator.ts
+++ b/packages/schema/src/types/fundamental/iterator.ts
@@ -1,8 +1,14 @@
 import { JSONObject, Option } from "ts-std";
 import { builders, dehydrated } from "../../descriptors";
+import {} from "../../descriptors/dehydrated";
+import { RegistryRecord } from "../../registry";
 import { ReferenceImpl } from "./reference";
 
 export class IteratorImpl extends ReferenceImpl {
+  static for(inner: RegistryRecord, kind: string): IteratorImpl {
+    return new IteratorImpl(inner.dictionary, inner.name, kind, inner.metadata);
+  }
+
   dehydrate(): dehydrated.Iterator {
     return {
       type: "Iterator",

--- a/packages/schema/src/types/fundamental/pointer.ts
+++ b/packages/schema/src/types/fundamental/pointer.ts
@@ -1,8 +1,13 @@
 import { JSONObject, Option } from "ts-std";
 import { builders, dehydrated } from "../../descriptors";
+import { RegistryRecord } from "../../registry";
 import { ReferenceImpl } from "./reference";
 
 export class PointerImpl extends ReferenceImpl {
+  static for(inner: RegistryRecord, kind: string): PointerImpl {
+    return new PointerImpl(inner.dictionary, inner.name, kind, inner.metadata);
+  }
+
   dehydrate(): dehydrated.Pointer {
     return {
       type: "Pointer",

--- a/packages/schema/src/types/fundamental/reference.ts
+++ b/packages/schema/src/types/fundamental/reference.ts
@@ -2,12 +2,12 @@ import { ValidationBuilder } from "@cross-check/dsl";
 import { JSONObject } from "ts-std";
 import { dehydrated } from "../../index";
 import { Type } from "../../type";
-import { DictionaryImpl } from "../../types/fundamental";
+import { DictionaryType } from "../../types/fundamental";
 import { ANY } from "./core";
 
 export abstract class ReferenceImpl implements Type {
   constructor(
-    protected type: DictionaryImpl,
+    protected type: DictionaryType,
     readonly name: string,
     readonly kind: string,
     readonly metadata: JSONObject | null

--- a/packages/schema/test/detailed-test.ts
+++ b/packages/schema/test/detailed-test.ts
@@ -75,7 +75,8 @@ mod.test("published documents", async (assert, { validate }) => {
       tags: null,
       categories: null,
       geo: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }),
     [
       typeError("string:single-line", "hed"),
@@ -98,7 +99,8 @@ mod.test("published documents", async (assert, { validate }) => {
       issueDate: null,
       canonicalUrl: null,
       geo: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }),
     [typeError("string", "tags.0"), typeError("string", "tags.2")],
     "if an optional field is present, it must match the schema"
@@ -127,7 +129,8 @@ mod.test("dates (issueDate)", async (assert, { validate }) => {
       canonicalUrl: null,
       tags: null,
       geo: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }),
     [typeError("iso-date", "issueDate")]
   );
@@ -161,7 +164,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       author: null,
       canonicalUrl: null,
       tags: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }),
     [missingError("geo.lat"), missingError("geo.long")],
     "published documents must include nested required fields if dictionary is present"
@@ -179,7 +183,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       geo: null,
       canonicalUrl: null,
       tags: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }),
     [],
     "published documents may leave out optional dictionaries"
@@ -197,7 +202,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       tags: null,
       contributors: null,
       categories: null,
-      geo: null
+      geo: null,
+      relatedArticles: null
     }),
     [missingError("categories")],
     "published documents may not leave out required dictionaries"
@@ -232,7 +238,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       author: null,
       canonicalUrl: null,
       tags: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }),
     [typeError("number", "geo.lat"), typeError("number", "geo.long")],
     "nested fields in published documents use the record type (but numbers aren't strings)"
@@ -250,7 +257,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       author: null,
       canonicalUrl: null,
       tags: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }),
     [
       typeError("number:integer", "geo.lat"),
@@ -280,7 +288,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       canonicalUrl: null,
       tags: null,
       contributors: null,
-      geo: null
+      geo: null,
+      relatedArticles: null
     }),
     [typeError("string:single-line", "author.first")],
     "nested fields in published documents use the record type (multiline strings are not valid single-line strings)"
@@ -315,7 +324,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       canonicalUrl: null,
       tags: null,
       contributors: null,
-      author: null
+      author: null,
+      relatedArticles: null
     }),
     [missingError("geo.lat"), missingError("geo.long")],
     "published documents must include nested required fields if dictionary is present"
@@ -333,7 +343,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       tags: null,
       contributors: null,
       geo: null,
-      author: null
+      author: null,
+      relatedArticles: null
     }),
     [],
     "published documents may leave out optional dictionaries"
@@ -351,7 +362,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       contributors: null,
       geo: null,
       categories: null,
-      author: null
+      author: null,
+      relatedArticles: null
     }),
     [missingError("categories")],
     "published documents may not leave out required dictionaries"
@@ -378,7 +390,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       canonicalUrl: null,
       tags: null,
       contributors: null,
-      author: null
+      author: null,
+      relatedArticles: null
     }),
     [typeError("number", "geo.lat"), typeError("number", "geo.long")],
     "nested fields in published documents use the record type (but numbers aren't strings)"
@@ -405,7 +418,8 @@ mod.test("optional dictionaries (geo)", async (assert, { validate }) => {
       canonicalUrl: null,
       tags: null,
       contributors: null,
-      geo: null
+      geo: null,
+      relatedArticles: null
     }),
     [typeError("string:single-line", "author.first")],
     "nested fields in published documents use the record type (multiline strings are not valid single-line strings)"
@@ -425,7 +439,8 @@ mod.test("required lists (categories)", async (assert, { validate }) => {
       canonicalUrl: null,
       tags: null,
       contributors: null,
-      author: null
+      author: null,
+      relatedArticles: null
     }),
     [typeError("present-array", "categories")],
     "in published documents, required lists must have at least one element"
@@ -454,7 +469,8 @@ mod.test("required lists (categories)", async (assert, { validate }) => {
       tags: null,
       contributors: null,
       author: null,
-      categories: null
+      categories: null,
+      relatedArticles: null
     }),
     [typeError("present", "categories")],
     "in published documents, required lists may not be missing"
@@ -484,7 +500,8 @@ mod.test("optional lists (tags)", async (assert, { validate }) => {
       issueDate: null,
       canonicalUrl: null,
       contributors: null,
-      author: null
+      author: null,
+      relatedArticles: null
     }),
     [],
     "in published documents, optional lists may be empty"
@@ -514,7 +531,8 @@ mod.test("optional lists (tags)", async (assert, { validate }) => {
       canonicalUrl: null,
       tags: null,
       contributors: null,
-      author: null
+      author: null,
+      relatedArticles: null
     }),
     [],
     "in published documents, optional lists may be missing"
@@ -549,7 +567,8 @@ mod.test("parsing", (assert, { registry }) => {
       tags: null,
       categories: ["one category", "two categories"],
       geo: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }
   );
 
@@ -564,7 +583,8 @@ mod.test("parsing", (assert, { registry }) => {
       tags: null,
       categories: ["one category", "two categories"],
       geo: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }),
     {
       hed: "Hello world",
@@ -576,7 +596,8 @@ mod.test("parsing", (assert, { registry }) => {
       tags: null,
       categories: ["one category", "two categories"],
       geo: null,
-      contributors: null
+      contributors: null,
+      relatedArticles: null
     }
   );
 
@@ -604,7 +625,8 @@ mod.test("parsing", (assert, { registry }) => {
         { first: "Dan" },
         { last: "Ohara" },
         { first: "Godfrey", last: "Chan" }
-      ]
+      ],
+      relatedArticles: null
     }),
     {
       hed: "Hello world",
@@ -626,7 +648,8 @@ mod.test("parsing", (assert, { registry }) => {
         { first: "Dan", last: null },
         { first: null, last: "Ohara" },
         { first: "Godfrey", last: "Chan" }
-      ]
+      ],
+      relatedArticles: null
     }
   );
 });

--- a/packages/schema/test/detailed-test.ts
+++ b/packages/schema/test/detailed-test.ts
@@ -14,6 +14,7 @@ function create(object: Dict = {}) {
     categories: null,
     geo: null,
     contributors: null,
+    relatedArticles: null,
     ...object
   };
 }

--- a/packages/schema/test/formatting/describe-test.ts
+++ b/packages/schema/test/formatting/describe-test.ts
@@ -52,7 +52,8 @@ mod.test("detailed", (assert, { format }) => {
         contributors?: list of {
           first?: <single line string>,
           last?: <single line string>
-        }
+        },
+        relatedArticles?: has many MediumArticle
       }
     `
   );

--- a/packages/schema/test/formatting/graphql-test.ts
+++ b/packages/schema/test/formatting/graphql-test.ts
@@ -66,6 +66,7 @@ mod.test("detailed", (assert, { format }) => {
       categories: [SingleLine!]!
       geo: MediumArticleGeo
       contributors: [MediumArticleContributors!]
+      relatedArticles: [MediumArticle!]
     }
     `
   );

--- a/packages/schema/test/formatting/list-types-test.ts
+++ b/packages/schema/test/formatting/list-types-test.ts
@@ -19,6 +19,7 @@ mod.test("detailed", (assert, { env }) => {
     "ISODate",
     "Integer",
     "List",
+    "MediumArticle",
     "SingleLine",
     "SingleWord",
     "Text",
@@ -32,6 +33,7 @@ mod.test("detailed - draft", (assert, { env }) => {
     "ISODate",
     "Integer",
     "List",
+    "MediumArticle",
     "Text"
   ]);
 });

--- a/packages/schema/test/formatting/schema-format-test.ts
+++ b/packages/schema/test/formatting/schema-format-test.ts
@@ -43,7 +43,8 @@ mod.test("detailed - published", (assert, { format }) => {
         contributors: List(Dictionary({
           first: SingleLine(),
           last: SingleLine()
-        }))
+        })),
+        relatedArticles: hasMany(MediumArticle)
       }).metadata({
         collectionName: "medium-articles",
         modelName: "medium-article"

--- a/packages/schema/test/formatting/to-json-test.ts
+++ b/packages/schema/test/formatting/to-json-test.ts
@@ -55,6 +55,15 @@ mod.test("detailed - published", (assert, { format }) => {
     },
 
     issueDate: { type: "ISODate", required: false },
+    relatedArticles: {
+      type: "Iterator",
+      kind: "hasMany",
+      of: {
+        alias: "MediumArticle",
+        required: true
+      },
+      required: false
+    },
     canonicalUrl: { type: "Url", args: [], required: false },
     tags: {
       type: "List",
@@ -131,6 +140,15 @@ mod.test("detailed - draft", (assert, { format }) => {
     },
 
     issueDate: { type: "ISODate", required: false },
+    relatedArticles: {
+      type: "Iterator",
+      kind: "hasMany",
+      of: {
+        alias: "MediumArticle",
+        required: true
+      },
+      required: false
+    },
     canonicalUrl: { type: "Text", required: false, args: { allowEmpty: true } },
     tags: {
       type: "List",

--- a/packages/schema/test/formatting/typescript-test.ts
+++ b/packages/schema/test/formatting/typescript-test.ts
@@ -57,6 +57,7 @@ mod.test("detailed - published", (assert, { format }) => {
           first?: string;
           last?: string;
         }>;
+        relatedArticles?: Array<MediumArticle>;
       }
     `
   );
@@ -89,6 +90,7 @@ mod.test("detailed - draft", (assert, { format }) => {
           first?: string;
           last?: string;
         }>;
+        relatedArticles?: Array<MediumArticle>;
       }
     `
   );

--- a/packages/schema/test/support/records.ts
+++ b/packages/schema/test/support/records.ts
@@ -45,7 +45,8 @@ export const MediumArticle: Record = Record("MediumArticle", {
     }),
     contributors: types.List(
       types.Dictionary({ first: types.SingleLine(), last: types.SingleLine() })
-    )
+    ),
+    relatedArticles: types.hasMany("MediumArticle")
   },
   metadata: {
     collectionName: "medium-articles",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7044,7 +7044,7 @@ tslint@*, tslint@^5.11.0:
     tslib "^1.8.0"
     tsutils "^2.27.2"
 
-tsutils@^2.12.1, tsutils@^2.27.2:
+tsutils@^2.27.2:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==


### PR DESCRIPTION
The short explanation is that as we dehydrate descriptors, we keep a map of the descriptors we've already seen, and avoid reifying them if they were already hydrated.

The one wrinkle is that we put a placeholder in the map while we are hydrating to avoid infinite regress, and that placeholder is not valid until hydration of the entire root type is complete.

This means that if somehow descriptor hydration interleaves with using the descriptor with the runtime, you will get a runtime error. But it's hard to imagine how that would even happen. Let's not do that please?