### PR TITLE
Add isoDate validator + isoDate schema type

### DIFF
--- a/packages/dsl/src/validators/is.ts
+++ b/packages/dsl/src/validators/is.ts
@@ -80,4 +80,25 @@ export class IsArrayValidator extends BasicValidator<unknown> {
   }
 }
 
+export class IsISODateStringValidator extends BasicValidator<unknown> {
+  static validatorName = "is-ISODateString";
+
+  validate(value: unknown): ValidationError[] {
+    if (value === undefined) {
+        return [];
+    }
+    let parsed = Date.parse(value);
+
+    if (isNaN(parsed))
+      return [{ path: [], message: { name: "ISODateString" } }];
+  
+    if (value === new Date(parsed).toISOString()) {
+      return [];
+    } else {
+      return [{ path: [], message: { name: "ISODateString" } }];
+    }
+  }
+}
+
 export const isArray = builderFor(IsArrayValidator);
+export const isISODateString = builderFor(IsISODateStringValidator);

--- a/packages/dsl/src/validators/is.ts
+++ b/packages/dsl/src/validators/is.ts
@@ -83,19 +83,19 @@ export class IsArrayValidator extends BasicValidator<unknown> {
 export class IsISODateStringValidator extends BasicValidator<unknown> {
   static validatorName = "is-ISODateString";
 
-  validate(value: unknown): ValidationError[] {
+  validate(value: string): ValidationError[] {
     if (value === undefined) {
         return [];
     }
     let parsed = Date.parse(value);
 
     if (isNaN(parsed))
-      return [{ path: [], message: { name: "ISODateString" } }];
+      return [{ path: [], message: { name: "type", details: "ISODateString" } }];
   
     if (value === new Date(parsed).toISOString()) {
       return [];
     } else {
-      return [{ path: [], message: { name: "ISODateString" } }];
+      return [{ path: [], message: { name: "type", details: "ISODateString" } }];
     }
   }
 }

--- a/packages/dsl/test/validators/is-test.ts
+++ b/packages/dsl/test/validators/is-test.ts
@@ -322,3 +322,13 @@ QUnit.test("isArray", async assert => {
   );
   assert.deepEqual(await run(validators.isArray(), "hello"), failure("array"));
 });
+
+QUnit.test("isISODateString", async assert => {
+  assert.equal(format(validates(validators.isISODateString())), `(is-ISODateString)`);
+
+  assert.deepEqual(await run(validators.isISODateString(), undefined), success());
+  assert.deepEqual(await run(validators.isISODateString(), new Date().toISOString()), success());
+
+  assert.deepEqual(await run(validators.isISODateString(), null), failure("ISODateString"));
+  assert.deepEqual(await run(validators.isISODateString(), "hello"), failure("ISODateString"));
+});

--- a/packages/schema/src/types/std/scalars.ts
+++ b/packages/schema/src/types/std/scalars.ts
@@ -155,6 +155,15 @@ export const SingleWord = scalar("SingleWord", {
   buildArgs: buildTextArgs
 });
 
+export const ISODate = scalar("ISODate", {
+  description: "ISO date",
+  typescript: "ISODate",
+
+  validation() {
+    return validators.isISODateString();
+  }
+});
+
 // tslint:disable-next-line:variable-name
 export const Boolean = scalar("Boolean", {
   description: "boolean",

--- a/packages/schema/test/extends-test.ts
+++ b/packages/schema/test/extends-test.ts
@@ -18,6 +18,7 @@ mod.test(
         hed: null,
         dek: null,
         body: null,
+        issueDate: null,
         byline: null
       }),
       [],

--- a/packages/schema/test/formatting/describe-test.ts
+++ b/packages/schema/test/formatting/describe-test.ts
@@ -10,7 +10,8 @@ mod.test("simple", (assert, { format }) => {
       {
         hed: <single line string>,
         dek?: <string>,
-        body: <string>
+        body: <string>,
+        issueDate?: <ISO Date>
       }
     `
   );

--- a/packages/schema/test/formatting/graphql-test.ts
+++ b/packages/schema/test/formatting/graphql-test.ts
@@ -13,6 +13,7 @@ mod.test("simple", (assert, { format }) => {
         hed: SingleLine!
         dek: String
         body: String!
+        issueDate: ISODate
       }
     `
   );
@@ -27,6 +28,7 @@ mod.test("simple", (assert, { format }) => {
         hed: String
         dek: String
         body: String
+        issueDate: ISODate
       }
     `
   );

--- a/packages/schema/test/formatting/list-types-test.ts
+++ b/packages/schema/test/formatting/list-types-test.ts
@@ -4,13 +4,14 @@ const mod = module("[schema] formatting - listTypes");
 
 mod.test("simple", (assert, { env }) => {
   assert.deepEqual(env.published.listTypes("SimpleArticle"), [
+    "ISODate",
     "SingleLine",
     "Text"
   ]);
 });
 
 mod.test("simple - draft", (assert, { env }) => {
-  assert.deepEqual(env.draft.listTypes("SimpleArticle"), ["Text"]);
+  assert.deepEqual(env.draft.listTypes("SimpleArticle"), ["ISODate", "Text"]);
 });
 
 mod.test("detailed", (assert, { env }) => {

--- a/packages/schema/test/formatting/schema-format-test.ts
+++ b/packages/schema/test/formatting/schema-format-test.ts
@@ -10,7 +10,8 @@ mod.test("simple", (assert, { format }) => {
       Record("SimpleArticle", {
         hed: SingleLine().required(),
         dek: Text(),
-        body: Text().required()
+        body: Text().required(),
+        issueDate: ISODate()
       }).metadata({
         collectionName: "simple-articles",
         modelName: "simple-article"

--- a/packages/schema/test/formatting/to-json-test.ts
+++ b/packages/schema/test/formatting/to-json-test.ts
@@ -7,7 +7,8 @@ mod.test("simple - published", (assert, { format }) => {
     fields: {
       hed: { type: "SingleLine", required: true },
       dek: { type: "Text", required: false, args: { allowEmpty: true } },
-      body: { type: "Text", required: true }
+      body: { type: "Text", required: true },
+      issueDate: { type: "ISODate", required: false }
     },
 
     metadata: {
@@ -22,7 +23,8 @@ mod.test("simple - draft", (assert, { format }) => {
     fields: {
       hed: { type: "Text", required: false, args: { allowEmpty: true } },
       dek: { type: "Text", required: false, args: { allowEmpty: true } },
-      body: { type: "Text", required: false, args: { allowEmpty: true } }
+      body: { type: "Text", required: false, args: { allowEmpty: true } },
+      issueDate: { type: "ISODate", required: false }
     },
     metadata: {
       collectionName: "simple-articles",

--- a/packages/schema/test/formatting/typescript-test.ts
+++ b/packages/schema/test/formatting/typescript-test.ts
@@ -11,6 +11,7 @@ mod.test("simple - published", (assert, { format }) => {
           hed: string;
           dek?: string;
           body: string;
+          issueDate?: Date;
         }
       `
   );
@@ -27,6 +28,7 @@ mod.test("simple - draft", (assert, { format }) => {
           hed?: string;
           dek?: string;
           body?: string;
+          issueDate?: Date;
         }
       `
   );

--- a/packages/schema/test/simple-test.ts
+++ b/packages/schema/test/simple-test.ts
@@ -18,7 +18,8 @@ mod.test(
       await validateDraft(SimpleArticle, registry, {
         hed: null,
         dek: null,
-        body: null
+        body: null,
+        issueDate: null,
       }),
       [],
       "all fields can be null in drafts"
@@ -68,7 +69,8 @@ mod.test(
       await validateDraft(SimpleArticle, registry, {
         hed: "Hello world\nMultiline strings are allowed in SingleLine",
         dek: "Hello, the cool world!",
-        body: null
+        body: null,
+        issueDate: null
       }),
       [],
       "draft mode can accept the widened type"
@@ -81,7 +83,8 @@ mod.test("published drafts must be narrow", async (assert, { registry }) => {
     await validatePublished(SimpleArticle, registry, {
       hed: "Hello world\nProblem here!",
       dek: "Hello, the cool world!",
-      body: null
+      body: null,
+      issueDate: null
     }),
     [typeError("string:single-line", "hed"), missingError("body")],
     "published records must not be missing fields or have the widened type"
@@ -97,7 +100,8 @@ mod.test(
 
         // dek is allowed to be an empty string, because its type is not required
         dek: "",
-        body: ""
+        body: "",
+        issueDate: null 
       }),
       [
         {
@@ -129,6 +133,7 @@ mod.test("parsing", (assert, { registry }) => {
     {
       hed: "Hello world",
       dek: null,
+      issueDate: null,
       body: "The body"
     }
   );
@@ -137,12 +142,14 @@ mod.test("parsing", (assert, { registry }) => {
     SimpleArticle.with({ registry }).parse({
       hed: "Hello world",
       dek: "Hello. Hello world.",
-      body: "The body"
+      body: "The body",
+      issueDate: null 
     }),
     {
       hed: "Hello world",
       dek: "Hello. Hello world.",
-      body: "The body"
+      body: "The body",
+      issueDate: null 
     }
   );
 });
@@ -152,6 +159,7 @@ mod.test("serialize", (assert, { registry }) => {
     SimpleArticle.with({ registry }).serialize({
       hed: "Hello world",
       dek: null,
+      issueDate: null,
       body: "The body"
     }),
     {
@@ -164,6 +172,7 @@ mod.test("serialize", (assert, { registry }) => {
     SimpleArticle.with({ registry }).serialize({
       hed: "Hello world",
       dek: "Hello. Hello world.",
+      issueDate: null,
       body: "The body"
     }),
     {
@@ -179,7 +188,8 @@ mod.test("a valid published draft", async (assert, { registry }) => {
     await validatePublished(SimpleArticle, registry, {
       hed: "Hello world",
       dek: "Hello, the cool world!\nMultiline allowed here",
-      body: "Hello world.\nThis text is permitted.\nTotally fine."
+      body: "Hello world.\nThis text is permitted.\nTotally fine.",
+      issueDate: null
     }),
     [],
     "a valid draft"
@@ -209,7 +219,7 @@ mod.test("Invalid shape with strictKeys", async (assert, { registry }) => {
     await validatePublished(SimpleArticle, registry, {}),
     [
       keysError({
-        missing: ["hed", "dek", "body"]
+        missing: ["hed", "dek", "body", "issueDate"]
       })
     ],
     "missing all fields"
@@ -218,7 +228,8 @@ mod.test("Invalid shape with strictKeys", async (assert, { registry }) => {
   assert.deepEqual(
     await validatePublished(SimpleArticle, registry, {
       hed: "Hello world",
-      dek: "Hello, the cool world!"
+      dek: "Hello, the cool world!",
+      issueDate: null
     }),
     [
       keysError({
@@ -233,7 +244,8 @@ mod.test("Invalid shape with strictKeys", async (assert, { registry }) => {
       hed: "Hello world",
       dek: "Hello, the cool world!",
       body: "Hello!!!",
-      wat: "dis"
+      wat: "dis",
+      issueDate: null
     }),
     [
       keysError({
@@ -247,6 +259,7 @@ mod.test("Invalid shape with strictKeys", async (assert, { registry }) => {
     await validatePublished(SimpleArticle, registry, {
       hed: "Hello world",
       dek: "Hello, the cool world!",
+      issueDate: null,
       wat: "dis"
     }),
     [

--- a/packages/schema/test/support/records.ts
+++ b/packages/schema/test/support/records.ts
@@ -12,7 +12,8 @@ export const SimpleArticle: Record = Record("SimpleArticle", {
   fields: {
     hed: types.SingleLine().required(),
     dek: types.Text(),
-    body: types.Text().required()
+    body: types.Text().required(),
+    issueDate: types.ISODate(),
   },
   metadata: {
     collectionName: "simple-articles",


### PR DESCRIPTION
This adds the ISODate type + the ISODateString validator.

New tests were written for the ISODateString validator. 

As far as testing the newly added ISODate type -- An `ISODate` type field was added to the  `SimpleArticle` support fixture, which I felt was the most complete way to run the newly added type through its paces.

Ticket incoming.

CC:
@wycats @chancancode 