### PR TITLE
Create failing test for single word type validation

### DIFF
--- a/packages/schema/test/simple-test.ts
+++ b/packages/schema/test/simple-test.ts
@@ -7,7 +7,7 @@ import {
   validateDraft,
   validatePublished
 } from "./support";
-import { SimpleArticle } from "./support/records";
+import { SimpleArticle, SingleWordRecord } from "./support/records";
 
 const mod = module("[schema] - simple schema");
 
@@ -22,6 +22,19 @@ mod.test(
       }),
       [],
       "all fields can be null in drafts"
+    );
+  }
+);
+
+mod.test(
+  "Cannot add more than a single word into a field defined as SingleWord",
+  async (assert, { registry }) => {
+    assert.deepEqual(
+      await validateDraft(SingleWordRecord, registry, {
+        hed: "One two"
+      }),
+      [typeError("string:single-word", "hed")],
+      "error returned when adding two words to a SingleWord field"
     );
   }
 );

--- a/packages/schema/test/support/records.ts
+++ b/packages/schema/test/support/records.ts
@@ -20,6 +20,16 @@ export const SimpleArticle: Record = Record("SimpleArticle", {
   }
 });
 
+export const SingleWordRecord: Record = Record("SingleWordRecord", {
+  fields: {
+    hed: types.SingleWord().required()
+  },
+  metadata: {
+    collectionName: "single-word-records",
+    modelName: "single-word-record"
+  }
+});
+
 if (DEBUG_LOG === "debug") {
   // @ts-ignore
   // tslint:disable-next-line


### PR DESCRIPTION
This creates a failing test that illustrates string type errors are not being returned on draft validation (they are being returned on publish validation however).

I found this behavior surprising because other validations such as adding a string into a field specified as types.Integer() throws validation errors on both draft and publish validation.

To me it seems it would be prudent to standardize the behavior across all types.

I wonder if you can shed some light on the reasoning behind this distinction?