### PR TITLE
Mute required test

### DIFF
--- a/packages/schema/test/simple-test.ts
+++ b/packages/schema/test/simple-test.ts
@@ -10,18 +10,13 @@ import {
 } from "./support";
 import { SimpleArticle, RequiredFieldRecord } from "./support/records";
 
-import { validates, validators, mutePath } from "@cross-check/dsl";
-const { object } = validators;
-
 const mod = module("[schema] - simple schema");
 
 mod.test(
   "required field validation can be muted",
   async (assert, { registry }) => {
-    let b = RequiredFieldRecord.with({ strictKeys: false, draft: true, registry });
-
     assert.deepEqual(
-      await validateAndMute(b, {}),
+      await validateAndMute(RequiredFieldRecord, {}),
       [],
       "field defined as required('always') on the schema can be muted"
     );

--- a/packages/schema/test/simple-test.ts
+++ b/packages/schema/test/simple-test.ts
@@ -4,12 +4,29 @@ import {
   module,
   typeError,
   validate,
+  validateAndMute,
   validateDraft,
   validatePublished
 } from "./support";
-import { SimpleArticle } from "./support/records";
+import { SimpleArticle, RequiredFieldRecord } from "./support/records";
+
+import { validates, validators, mutePath } from "@cross-check/dsl";
+const { object } = validators;
 
 const mod = module("[schema] - simple schema");
+
+mod.test(
+  "required field validation can be muted",
+  async (assert, { registry }) => {
+    let b = RequiredFieldRecord.with({ strictKeys: false, draft: true, registry });
+
+    assert.deepEqual(
+      await validateAndMute(b, {}),
+      [],
+      "field defined as required('always') on the schema can be muted"
+    );
+  }
+);
 
 mod.test(
   "all fields are optional in draft mode",
@@ -25,6 +42,7 @@ mod.test(
     );
   }
 );
+
 
 mod.test(
   "extra fields are permitted when strictKeys is false in draft mode",

--- a/packages/schema/test/support/records.ts
+++ b/packages/schema/test/support/records.ts
@@ -26,6 +26,16 @@ if (DEBUG_LOG === "debug") {
   console.log(formatDescriptor(SimpleArticle.descriptor));
 }
 
+export const RequiredFieldRecord: Record = Record("RequiredFieldRecord", {
+  fields: {
+    hed: types.SingleWord().required('always')
+  },
+  metadata: {
+    collectionName: "required-field-records",
+    modelName: "required-field-record"
+  }
+});
+
 export const MediumArticle: Record = Record("MediumArticle", {
   fields: {
     hed: types.SingleLine().required("always"),

--- a/packages/schema/test/support/utils.ts
+++ b/packages/schema/test/support/utils.ts
@@ -5,6 +5,7 @@ import {
   RecordImpl,
   Registry
 } from "@cross-check/schema";
+import { mutePath } from "@cross-check/dsl";
 import { Task } from "no-show";
 import { Dict, Option } from "ts-std";
 
@@ -49,6 +50,13 @@ export function validate(
   obj: Dict<unknown>
 ): Task<ValidationError[]> {
   return record.validate(obj, ENV);
+}
+
+export function validateAndMute(
+  record: RecordImpl,
+  obj: Dict<unknown>
+): Task<ValidationError[]> {
+  return record.validate(obj, ENV).catch(mutePath['hed']);
 }
 
 export function validateDraft(


### PR DESCRIPTION
This creates a failing test that aims to demonstrate that properties specified as `required` on a schema definition cannot be muted in a way that other validation definitions can.